### PR TITLE
SEO improvements: meta, structured data, breadcrumbs

### DIFF
--- a/src/content/blog/architecting-hc.md
+++ b/src/content/blog/architecting-hc.md
@@ -1,6 +1,6 @@
 ---
 title: "Architecting hospital care"
-description: "A deep dive into designing effective hospital systems."
+description: "Why an outsider's perspective is a healthcare system architect's greatest asset — how decades in embedded systems engineering, Theory of Constraints, and AI provide a different lens on hospital operational challenges."
 date: 2025-08-09
 author: "John Sambrook"
 tags: ["Healthcare", "Architecture"]

--- a/src/content/blog/hidden-conflicts.md
+++ b/src/content/blog/hidden-conflicts.md
@@ -1,6 +1,6 @@
 ---
 title: "Hidden conflicts in healthcare"
-description: "How unspoken conflicts in healthcare organizations stall progress and erode trust."
+description: "Give me any healthcare policy document and I will show you embedded structural conflicts. A real hospital financial assistance policy analyzed using Theory of Constraints to reveal three critical dilemmas and paths to resolution."
 date: 2025-08-31
 author: "John Sambrook"
 tags: ["Leadership", "Strategy"]

--- a/src/content/blog/the-discharge-trap.md
+++ b/src/content/blog/the-discharge-trap.md
@@ -1,6 +1,6 @@
 ---
 title: "The discharge trap"
-description: "Why hospital discharge processes fail and how to fix them."
+description: "Hospital discharge planning fails because it treats a complex logistics problem as a last-minute task. This three-part series introduces the Post-Acute Care Directive — moving planning from the hospital bed to the primary care clinic."
 date: 2025-09-04
 author: "John Sambrook"
 tags: ["Healthcare", "Operations"]

--- a/src/content/blog/why-burnout-persists-series.md
+++ b/src/content/blog/why-burnout-persists-series.md
@@ -1,6 +1,6 @@
 ---
 title: "Why burnout persists"
-description: "Analyzing why healthcare teams remain chronically burned out."
+description: "Healthcare protects staff from radiation but expects unlimited psychological trauma absorption. This four-part series maps the structural conflict behind provider burnout using Theory of Constraints and proposes systemic solutions beyond resilience training."
 date: 2025-09-14
 author: "John Sambrook"
 tags: ["Healthcare", "Wellbeing"]

--- a/src/content/blog/why-is-hc-so-stuck.md
+++ b/src/content/blog/why-is-hc-so-stuck.md
@@ -1,6 +1,6 @@
 ---
 title: "Why healthcare is so stuck"
-description: "Exploring structural reasons behind stagnation in hospital systems."
+description: "Six chronic healthcare frustrations — long wait times, expensive insurance, claim denials, hiring difficulties, tax levies, and burnout — traced to a single root cause using Theory of Constraints analysis."
 date: 2025-09-17
 author: "John Sambrook"
 tags: ["Healthcare", "Analysis"]

--- a/src/data/pages/about.ts
+++ b/src/data/pages/about.ts
@@ -2,7 +2,7 @@ import type { PageHeader, ContentBlock, CTAContent } from "../types";
 
 export const pageTitle = "About";
 export const pageDescription =
-  "A healthcare consulting practice helping community hospital leaders make progress on complex, divisive problems.";
+  "Founded by John Sambrook, Common Sense Systems helps community hospital leaders in Washington, Oregon, Idaho, and Montana resolve complex operational problems using Theory of Constraints and systems thinking.";
 
 export const header: PageHeader = {
   label: "About",

--- a/src/data/pages/approach.ts
+++ b/src/data/pages/approach.ts
@@ -2,7 +2,7 @@ import type { PageHeader, GridItem, CTAContent } from "../types";
 
 export const pageTitle = "Approach";
 export const pageDescription =
-  "A practical, low-risk approach to making progress on complex problems in community hospitals.";
+  "A practical, fixed-fee consulting approach for community hospitals: problem framing, joint fact-finding, decision design, and short feedback cycles. No scope creep, no dependency.";
 
 export const header: PageHeader = {
   label: "Approach",

--- a/src/data/pages/contact.ts
+++ b/src/data/pages/contact.ts
@@ -2,7 +2,7 @@ import type { PageHeader } from "../types";
 
 export const pageTitle = "Contact";
 export const pageDescription =
-  "Get in touch with Common Sense Systems. No obligation, no sales pitch.";
+  "Schedule a free 30-minute consultation with Common Sense Systems. Healthcare operations consulting for community hospitals in the Pacific Northwest. No obligation, no sales pitch.";
 
 export const header: PageHeader = {
   label: "Contact",

--- a/src/data/schema.ts
+++ b/src/data/schema.ts
@@ -58,7 +58,6 @@ export function buildProfessionalServiceSchema(): Record<string, unknown> {
       addressCountry: 'US',
     },
     description: siteConfig.defaultDescription,
-    priceRange: '$',
     areaServed: 'US',
   };
 }
@@ -67,6 +66,7 @@ export function buildArticleSchema(options: {
   title: string;
   description: string;
   datePublished: string;
+  dateModified?: string;
   author: string;
   url: string;
 }): Record<string, unknown> {
@@ -76,6 +76,7 @@ export function buildArticleSchema(options: {
     headline: options.title,
     description: options.description,
     datePublished: options.datePublished,
+    dateModified: options.dateModified ?? options.datePublished,
     url: options.url,
     author: {
       '@type': 'Person',
@@ -101,5 +102,21 @@ export function buildBreadcrumbSchema(
       name: item.name,
       item: `${siteConfig.siteUrl}${item.href}`,
     })),
+  };
+}
+
+export function buildContactPageSchema(description: string): Record<string, unknown> {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'ContactPage',
+    name: `Contact ${siteConfig.name}`,
+    description,
+    url: `${siteConfig.siteUrl}/contact`,
+    mainEntity: {
+      '@type': 'Organization',
+      name: siteConfig.name,
+      telephone: footerContact.phones[0],
+      email: footerContact.email,
+    },
   };
 }

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -2,7 +2,7 @@ export const siteConfig = {
   name: "Common Sense Systems",
   tagline: "Delivering real business value since 1996",
   siteUrl: "https://common-sense.com",
-  defaultDescription: "Common Sense Systems - Delivering real business value since 1996",
+  defaultDescription: "Healthcare systems consulting for community hospitals. Common Sense Systems helps hospital leaders resolve operational conflicts, improve discharge processes, and address provider burnout through Theory of Constraints methodology and systems thinking.",
   defaultOgImage: "/images/og-default.png",
   headerCta: { text: "Book a Consultation", href: "/contact" },
   footerContactHeading: "Contact Us",

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -13,6 +13,7 @@ interface Props {
   title: string;
   description?: string;
   ogImage?: string;
+  ogType?: string;
   jsonLd?: Record<string, unknown>[];
 }
 
@@ -25,6 +26,7 @@ const {
   title,
   description = siteConfig.defaultDescription,
   ogImage = siteConfig.defaultOgImage,
+  ogType = "website",
   jsonLd = [],
 } = Astro.props;
 
@@ -53,7 +55,8 @@ const ogImageURL = Astro.site
   <link rel="canonical" href={canonicalURL} />
 
   <!-- Open Graph / Facebook -->
-  <meta property="og:type" content="website" />
+  <meta property="og:type" content={ogType} />
+  <meta property="og:locale" content="en_US" />
   <meta property="og:url" content={canonicalURL} />
   <meta property="og:title" content={title} />
   <meta property="og:description" content={description} />

--- a/src/layouts/BlogPostLayout.astro
+++ b/src/layouts/BlogPostLayout.astro
@@ -18,7 +18,7 @@ import Header from "../components/Header.astro";
 import Footer from "../components/Footer.astro";
 import Section from "../components/Section.astro";
 import { getPageTitle, headerDefaults, footerDefaults } from "../data/pageDefaults";
-import { buildArticleSchema } from "../data/schema";
+import { buildArticleSchema, buildBreadcrumbSchema } from "../data/schema";
 import { siteConfig } from "../data/site";
 
 const { title, description, date, author } = Astro.props;
@@ -32,12 +32,18 @@ const articleSchema = buildArticleSchema({
   title,
   description,
   datePublished: date.toISOString(),
+  dateModified: date.toISOString(),
   author,
   url: articleUrl,
 });
+const breadcrumb = buildBreadcrumbSchema([
+  { name: "Home", href: "/" },
+  { name: "Insights", href: "/insights" },
+  { name: title, href: Astro.url.pathname },
+]);
 ---
 
-<BaseLayout title={getPageTitle(title)} description={description} jsonLd={[articleSchema]}>
+<BaseLayout title={getPageTitle(title)} description={description} ogType="article" jsonLd={[articleSchema, breadcrumb]}>
   <Header slot="header" {...headerDefaults} currentPath={Astro.url.pathname} />
 
   <Section>

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -1,0 +1,38 @@
+---
+/*
+ * PageLayout.astro
+ *
+ * Layout for inner pages (About, Approach, Contact, Insights).
+ * Wraps BaseLayout with Header, Footer, and breadcrumb schema.
+ */
+
+interface Props {
+  pageTitle: string;
+  description?: string;
+  ogType?: string;
+  jsonLd?: Record<string, unknown>[];
+}
+
+import BaseLayout from "./BaseLayout.astro";
+import Header from "../components/Header.astro";
+import Footer from "../components/Footer.astro";
+import { getPageTitle, headerDefaults, footerDefaults } from "../data/pageDefaults";
+import { buildBreadcrumbSchema } from "../data/schema";
+
+const { pageTitle, description, ogType, jsonLd = [] } = Astro.props;
+
+const breadcrumb = buildBreadcrumbSchema([
+  { name: "Home", href: "/" },
+  { name: pageTitle, href: Astro.url.pathname },
+]);
+
+const allJsonLd = [breadcrumb, ...jsonLd];
+---
+
+<BaseLayout title={getPageTitle(pageTitle)} description={description} ogType={ogType} jsonLd={allJsonLd}>
+  <Header slot="header" {...headerDefaults} currentPath={Astro.url.pathname} />
+
+  <slot />
+
+  <Footer slot="footer" {...footerDefaults} />
+</BaseLayout>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,15 +1,11 @@
 ---
-import BaseLayout from "../layouts/BaseLayout.astro";
-import Header from "../components/Header.astro";
-import Footer from "../components/Footer.astro";
+import PageLayout from "../layouts/PageLayout.astro";
 import Section from "../components/Section.astro";
 import CTASection from "../components/CTASection.astro";
-import { getPageTitle, headerDefaults, footerDefaults } from "../data/pageDefaults";
 import { pageTitle, pageDescription, header, content, cta } from "../data/pages/about";
 ---
 
-<BaseLayout title={getPageTitle(pageTitle)} description={pageDescription}>
-  <Header slot="header" {...headerDefaults} currentPath={Astro.url.pathname} />
+<PageLayout pageTitle={pageTitle} description={pageDescription}>
 
   <Section background="muted">
     <div class="max-w-3xl mx-auto text-center space-y-4">
@@ -34,5 +30,4 @@ import { pageTitle, pageDescription, header, content, cta } from "../data/pages/
     secondaryCta={cta.secondaryCta}
   />
 
-  <Footer slot="footer" {...footerDefaults} />
-</BaseLayout>
+</PageLayout>

--- a/src/pages/approach.astro
+++ b/src/pages/approach.astro
@@ -1,15 +1,11 @@
 ---
-import BaseLayout from "../layouts/BaseLayout.astro";
-import Header from "../components/Header.astro";
-import Footer from "../components/Footer.astro";
+import PageLayout from "../layouts/PageLayout.astro";
 import Section from "../components/Section.astro";
 import CTASection from "../components/CTASection.astro";
-import { getPageTitle, headerDefaults, footerDefaults } from "../data/pageDefaults";
 import { pageTitle, pageDescription, header, steps, cta } from "../data/pages/approach";
 ---
 
-<BaseLayout title={getPageTitle(pageTitle)} description={pageDescription}>
-  <Header slot="header" {...headerDefaults} currentPath={Astro.url.pathname} />
+<PageLayout pageTitle={pageTitle} description={pageDescription}>
 
   <Section background="muted">
     <div class="max-w-3xl mx-auto text-center space-y-4">
@@ -38,5 +34,4 @@ import { pageTitle, pageDescription, header, steps, cta } from "../data/pages/ap
     footnote={cta.footnote}
   />
 
-  <Footer slot="footer" {...footerDefaults} />
-</BaseLayout>
+</PageLayout>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,15 +1,14 @@
 ---
-import BaseLayout from "../layouts/BaseLayout.astro";
-import Header from "../components/Header.astro";
-import Footer from "../components/Footer.astro";
+import PageLayout from "../layouts/PageLayout.astro";
 import Section from "../components/Section.astro";
-import { getPageTitle, headerDefaults, footerDefaults } from "../data/pageDefaults";
 import { footerContact } from "../data/site";
 import { pageTitle, pageDescription, header, availability } from "../data/pages/contact";
+import { buildContactPageSchema } from "../data/schema";
+
+const contactSchema = buildContactPageSchema(pageDescription);
 ---
 
-<BaseLayout title={getPageTitle(pageTitle)} description={pageDescription}>
-  <Header slot="header" {...headerDefaults} currentPath={Astro.url.pathname} />
+<PageLayout pageTitle={pageTitle} description={pageDescription} jsonLd={[contactSchema]}>
 
   <Section background="muted">
     <div class="max-w-3xl mx-auto text-center space-y-4">
@@ -36,5 +35,4 @@ import { pageTitle, pageDescription, header, availability } from "../data/pages/
     </div>
   </Section>
 
-  <Footer slot="footer" {...footerDefaults} />
-</BaseLayout>
+</PageLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,7 +12,7 @@ import { intakeFormConfig } from "../data/intakeForm";
 import { buildWebSiteSchema, buildProfessionalServiceSchema } from "../data/schema";
 ---
 
-<BaseLayout title={getPageTitle()} jsonLd={[buildWebSiteSchema(), buildProfessionalServiceSchema()]}>
+<BaseLayout title="Common Sense Systems | Healthcare Consulting for Community Hospitals" jsonLd={[buildWebSiteSchema(), buildProfessionalServiceSchema()]}>
   <Header slot="header" {...headerDefaults} currentPath={Astro.url.pathname} />
 
   <Hero

--- a/src/pages/insights.astro
+++ b/src/pages/insights.astro
@@ -1,18 +1,14 @@
 ---
 import { getCollection } from "astro:content";
-import BaseLayout from "../layouts/BaseLayout.astro";
-import Header from "../components/Header.astro";
-import Footer from "../components/Footer.astro";
+import PageLayout from "../layouts/PageLayout.astro";
 import Section from "../components/Section.astro";
-import { getPageTitle, headerDefaults, footerDefaults } from "../data/pageDefaults";
 import { pageTitle, pageDescription, header } from "../data/pages/insights";
 
 const posts = (await getCollection("blog", ({ data }) => !data.draft))
   .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
 ---
 
-<BaseLayout title={getPageTitle(pageTitle)} description={pageDescription}>
-  <Header slot="header" {...headerDefaults} currentPath={Astro.url.pathname} />
+<PageLayout pageTitle={pageTitle} description={pageDescription}>
 
   <Section background="muted">
     <div class="max-w-3xl mx-auto text-center space-y-4">
@@ -38,5 +34,4 @@ const posts = (await getCollection("blog", ({ data }) => !data.draft))
     </div>
   </Section>
 
-  <Footer slot="footer" {...footerDefaults} />
-</BaseLayout>
+</PageLayout>


### PR DESCRIPTION
## Summary

- **#16** Homepage title now includes "Healthcare Consulting for Community Hospitals"; site-wide default description rewritten with target keywords
- **#17** Blog posts render `og:type` as `"article"` instead of `"website"` via new `ogType` prop on BaseLayout
- **#18** Breadcrumb JSON-LD wired up on all inner pages (via new PageLayout) and blog posts (`Home > Insights > Post Title`)
- **#19** Rewrote thin meta descriptions on 5 blog posts (architecting-hc, the-discharge-trap, why-burnout-persists-series, why-is-hc-so-stuck, hidden-conflicts)
- **#20** Added `og:locale` `en_US` meta tag to BaseLayout
- **#21** Article schema now includes `dateModified` (falls back to `datePublished`)
- **#22** Contact page has ContactPage structured data with Organization mainEntity
- **#28** Removed misleading `priceRange: '$'` from ProfessionalService schema
- Updated page-level meta descriptions for About, Approach, and Contact

## Test plan

- [ ] `npm run build` succeeds
- [ ] `dist/index.html` title contains "Healthcare Consulting" and "Community Hospitals"
- [ ] `dist/index.html` has `og:locale` and `og:type="website"`
- [ ] Blog post HTML has `og:type="article"` and JSON-LD with both Article and BreadcrumbList schemas
- [ ] `dist/contact/index.html` has ContactPage JSON-LD
- [ ] `dist/about/index.html` and `dist/approach/index.html` have BreadcrumbList JSON-LD
- [ ] No visible page content changed (all changes are in `<head>` metadata and JSON-LD)

Closes #16, closes #17, closes #18, closes #19, closes #20, closes #21, closes #22, closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)