### PR TITLE
SEO: RSS feed, 404 description, noindex legal pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "cssi-web-template",
       "version": "0.1.0",
       "dependencies": {
+        "@astrojs/rss": "^4.0.15",
         "@astrojs/sitemap": "^3.7.0",
         "@tailwindcss/typography": "^0.5.19",
         "astro": "^5.0.0"
@@ -86,6 +87,16 @@
       },
       "engines": {
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@astrojs/rss": {
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.15.tgz",
+      "integrity": "sha512-uXO/k6AhRkIDXmRoc6xQpoPZrimQNUmS43X4+60yunfuMNHtSRN5e/FiSi7NApcZqmugSMc5+cJi8ovqgO+qIg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^5.3.3",
+        "piccolore": "^0.1.3"
       }
     },
     "node_modules/@astrojs/sitemap": {
@@ -3579,6 +3590,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-xml-parser": {
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.5.tgz",
+      "integrity": "sha512-JeaA2Vm9ffQKp9VjvfzObuMCjUYAp5WDYhRYL5LrBPY/jUDlUtOvDfot0vKSkB9tuX885BDHjtw4fZadD95wnA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.2"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -6475,6 +6504,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
+      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/sucrase": {
       "version": "3.35.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
+    "@astrojs/rss": "^4.0.15",
     "@astrojs/sitemap": "^3.7.0",
     "@tailwindcss/typography": "^0.5.19",
     "astro": "^5.0.0"

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -14,6 +14,7 @@ interface Props {
   description?: string;
   ogImage?: string;
   ogType?: string;
+  noindex?: boolean;
   jsonLd?: Record<string, unknown>[];
 }
 
@@ -27,6 +28,7 @@ const {
   description = siteConfig.defaultDescription,
   ogImage = siteConfig.defaultOgImage,
   ogType = "website",
+  noindex = false,
   jsonLd = [],
 } = Astro.props;
 
@@ -53,6 +55,7 @@ const ogImageURL = Astro.site
   <title>{title}</title>
   <meta name="description" content={description} />
   <link rel="canonical" href={canonicalURL} />
+  {noindex && <meta name="robots" content="noindex, nofollow" />}
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content={ogType} />
@@ -70,6 +73,11 @@ const ogImageURL = Astro.site
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+
+  <!-- RSS -->
+  <link rel="alternate" type="application/rss+xml"
+        title={siteConfig.name}
+        href="/rss.xml" />
 
   <!-- Structured Data -->
   <JsonLd schemas={[buildOrganizationSchema(), ...jsonLd]} />

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -10,6 +10,7 @@ interface Props {
   pageTitle: string;
   description?: string;
   ogType?: string;
+  noindex?: boolean;
   jsonLd?: Record<string, unknown>[];
 }
 
@@ -19,7 +20,7 @@ import Footer from "../components/Footer.astro";
 import { getPageTitle, headerDefaults, footerDefaults } from "../data/pageDefaults";
 import { buildBreadcrumbSchema } from "../data/schema";
 
-const { pageTitle, description, ogType, jsonLd = [] } = Astro.props;
+const { pageTitle, description, ogType, noindex, jsonLd = [] } = Astro.props;
 
 const breadcrumb = buildBreadcrumbSchema([
   { name: "Home", href: "/" },
@@ -29,7 +30,7 @@ const breadcrumb = buildBreadcrumbSchema([
 const allJsonLd = [breadcrumb, ...jsonLd];
 ---
 
-<BaseLayout title={getPageTitle(pageTitle)} description={description} ogType={ogType} jsonLd={allJsonLd}>
+<BaseLayout title={getPageTitle(pageTitle)} description={description} ogType={ogType} noindex={noindex} jsonLd={allJsonLd}>
   <Header slot="header" {...headerDefaults} currentPath={Astro.url.pathname} />
 
   <slot />

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -6,7 +6,7 @@ import Section from "../components/Section.astro";
 import { getPageTitle, headerDefaults, footerDefaults } from "../data/pageDefaults";
 ---
 
-<BaseLayout title={getPageTitle("Page Not Found")}>
+<BaseLayout title={getPageTitle("Page Not Found")} description="The page you requested could not be found. Return to the Common Sense Systems homepage to explore healthcare consulting insights and services.">
   <Header slot="header" {...headerDefaults} currentPath={Astro.url.pathname} />
 
   <Section>

--- a/src/pages/legal/privacy.astro
+++ b/src/pages/legal/privacy.astro
@@ -8,7 +8,7 @@ import { footerContact } from "../../data/site";
 import { pageTitle, pageDescription, lastUpdated, content } from "../../data/pages/privacy";
 ---
 
-<BaseLayout title={getPageTitle(pageTitle)} description={pageDescription}>
+<BaseLayout title={getPageTitle(pageTitle)} description={pageDescription} noindex={true}>
   <Header slot="header" {...headerDefaults} currentPath={Astro.url.pathname} />
 
   <Section>

--- a/src/pages/legal/terms.astro
+++ b/src/pages/legal/terms.astro
@@ -8,7 +8,7 @@ import { footerContact } from "../../data/site";
 import { pageTitle, pageDescription, lastUpdated, content } from "../../data/pages/terms";
 ---
 
-<BaseLayout title={getPageTitle(pageTitle)} description={pageDescription}>
+<BaseLayout title={getPageTitle(pageTitle)} description={pageDescription} noindex={true}>
   <Header slot="header" {...headerDefaults} currentPath={Astro.url.pathname} />
 
   <Section>

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,0 +1,20 @@
+import rss from '@astrojs/rss';
+import { getCollection } from 'astro:content';
+import { siteConfig } from '../data/site';
+
+export async function GET(context: { site: URL }) {
+  const posts = (await getCollection('blog', ({ data }) => !data.draft))
+    .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
+
+  return rss({
+    title: siteConfig.name,
+    description: siteConfig.defaultDescription,
+    site: context.site,
+    items: posts.map((post) => ({
+      title: post.data.title,
+      description: post.data.description,
+      pubDate: post.data.date,
+      link: `/insights/${post.id}/`,
+    })),
+  });
+}


### PR DESCRIPTION
## Summary
- **RSS feed (#27):** Install `@astrojs/rss`, create `/rss.xml` endpoint with all published blog posts, add RSS autodiscovery `<link>` to `<head>`
- **404 meta description (#30):** Replace generic site default with a page-specific description
- **Noindex legal pages (#31):** Add `noindex` boolean prop to `BaseLayout`/`PageLayout`, apply to privacy policy and terms of service pages

## Test plan
- [ ] `npm run build` succeeds
- [ ] `dist/rss.xml` exists with valid XML and correct `/insights/{slug}/` links
- [ ] `dist/index.html` contains RSS autodiscovery `<link>` in `<head>`
- [ ] `dist/404.html` meta description is the custom text, not the site default
- [ ] `dist/legal/privacy/index.html` has `<meta name="robots" content="noindex, nofollow" />`
- [ ] `dist/legal/terms/index.html` has `<meta name="robots" content="noindex, nofollow" />`
- [ ] `dist/about/index.html` does NOT have a noindex robots tag

Closes #27, #30, #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)